### PR TITLE
.travis.yml: initial version for travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+# Copyright Siemens AG, 2014
+# SPDX-License-Identifier:    BSD-2-Clause
+
+language: cpp
+compiler:
+  - gcc
+  - clang
+install:
+  - sudo apt-get install -qq cppcheck
+  - sudo add-apt-repository --yes ppa:kalakris/cmake
+  - sudo apt-get update -qq
+  - sudo apt-get install cmake
+script:
+  - cppcheck -q --enable=all *_c*
+  - mkdir build && cd build
+  - cmake ..
+  - make
+  - chmod a+x binaries/run_tests.sh
+  - ./binaries/run_tests.sh


### PR DESCRIPTION
This is an initial version of a .travis.yml to build each commit and pull request of embb.
see https://travis-ci.org/bufferoverflow/embb/builds/37236748 as an example.
clang build is currently broken ... feel free to remove it from .travis.yml or fix it ;-)
all the best!
-roger

PS: I've already activated the travis-ci hook on siemens/embb

;-r
