### PR TITLE
Optimized spinlock, consistent use of (implicit) "lock" prefix for xchg.

### DIFF
--- a/base_c/include/embb/base/c/internal/atomic/store.h
+++ b/base_c/include/embb/base/c/internal/atomic/store.h
@@ -57,8 +57,7 @@
 #define EMBB_DEFINE_STORE(EMBB_PARAMETER_SIZE_BYTE, EMBB_ATOMIC_X86_SIZE_SUFFIX)\
   EMBB_PLATFORM_INLINE void EMBB_CAT2(embb_internal__atomic_store_, EMBB_PARAMETER_SIZE_BYTE)(EMBB_CAT2(EMBB_BASE_BASIC_TYPE_SIZE_, EMBB_PARAMETER_SIZE_BYTE) volatile* pointer_to_value, \
   EMBB_CAT2(EMBB_BASE_BASIC_TYPE_SIZE_, EMBB_PARAMETER_SIZE_BYTE) new_value) {\
-  /*the lock prefix is implicit for xchg*/  \
-  __asm__ __volatile__("xchg" EMBB_ATOMIC_X86_SIZE_SUFFIX " %1, %0" \
+  __asm__ __volatile__("lock xchg" EMBB_ATOMIC_X86_SIZE_SUFFIX " %1, %0" \
   : "+m" (*pointer_to_value), "+q" (new_value) \
   : \
   : "memory"); \

--- a/base_c/include/embb/base/c/internal/atomic/swap.h
+++ b/base_c/include/embb/base/c/internal/atomic/swap.h
@@ -58,8 +58,7 @@
   EMBB_PLATFORM_INLINE EMBB_CAT2(EMBB_BASE_BASIC_TYPE_SIZE_, EMBB_PARAMETER_SIZE_BYTE) EMBB_CAT2(embb_internal__atomic_swap_, EMBB_PARAMETER_SIZE_BYTE)(\
   EMBB_CAT2(EMBB_BASE_BASIC_TYPE_SIZE_, EMBB_PARAMETER_SIZE_BYTE) volatile* pointer_to_value, EMBB_CAT2(EMBB_BASE_BASIC_TYPE_SIZE_, EMBB_PARAMETER_SIZE_BYTE) new_value)\
   { \
-  /*the lock prefix is implicit for xchg*/  \
-  __asm__ __volatile__("xchg" EMBB_ATOMIC_X86_SIZE_SUFFIX " %1, %0" \
+  __asm__ __volatile__("lock xchg" EMBB_ATOMIC_X86_SIZE_SUFFIX " %1, %0" \
   : "+m" (*pointer_to_value), "+q" (new_value) \
   : \
   : "memory"); \

--- a/base_c/src/atomicfunc_32.asm
+++ b/base_c/src/atomicfunc_32.asm
@@ -114,7 +114,7 @@ define_or_assign @embb_internal__atomic_or_assign_1_asm@8, byte, dl
 define_store macro name, size, value
 	public name
 	name proc
-		xchg size ptr [ecx], value
+		lock xchg size ptr [ecx], value
 		ret
 	name endp
 endm

--- a/base_c/src/atomicfunc_64.asm
+++ b/base_c/src/atomicfunc_64.asm
@@ -107,7 +107,7 @@ define_or_assign embb_internal__atomic_or_assign_1_asm, byte, dl
 define_store macro name, size, value
 	public name
 	name proc
-		xchg size ptr [rcx], value
+		lock xchg size ptr [rcx], value
 		ret
 	name endp
 endm


### PR DESCRIPTION
Resolves #43 